### PR TITLE
Fix: upgrade jackson and revert logback version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,13 @@
         <commons-io.version>2.11.0</commons-io.version>
         <ehcache.version>2.9.0</ehcache.version>
         <ehcache-web.version>2.0.4</ehcache-web.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
         <hibernate-jpamodelgen.version>1.3.0.Final</hibernate-jpamodelgen.version>
         <hibernate-jpa-api.version>1.0.0.Final</hibernate-jpa-api.version>
         <hsqldb.version>2.5.1</hsqldb.version>
         <junit.version>4.13.2</junit.version>
-        <logback.version>1.4.5</logback.version>
+        <logback.version>1.3.5</logback.version>
         <persistence-api.version>1.0</persistence-api.version>
         <resource-server.version>1.3.1</resource-server.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
Logback classic reverted to 1.3.5 to work for Java 8, and applied security patch with upgraded jackson version 