### PR TITLE
UPSE-385: Fix portlet config cancel (was doing save)

### DIFF
--- a/src/main/java/org/jasig/portlet/cms/mvc/portlet/ConfigureContentController.java
+++ b/src/main/java/org/jasig/portlet/cms/mvc/portlet/ConfigureContentController.java
@@ -36,6 +36,7 @@ import org.jasig.portlet.cms.service.dao.IContentDao;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.portlet.bind.annotation.ResourceMapping;
@@ -109,6 +110,11 @@ public class ConfigureContentController {
         this.contentDao.saveContent(request, content, locale);
         
         // exit the portlet's configuration mode
+        response.setPortletMode(PortletMode.VIEW);
+    }
+
+    @PostMapping(params="action=cancel")
+    public void cancel(ActionRequest request, ActionResponse response) throws PortletModeException {
         response.setPortletMode(PortletMode.VIEW);
     }
 

--- a/src/main/webapp/WEB-INF/jsp/configureContent.jsp
+++ b/src/main/webapp/WEB-INF/jsp/configureContent.jsp
@@ -22,7 +22,7 @@
 <c:set var="includeJQuery" value="${renderRequest.preferences.map['includeJQuery'][0]}"/>
 <c:set var="n"><portlet:namespace/></c:set>
 <portlet:actionURL var="formUrl" escapeXml="false"><portlet:param name="action" value="updateConfiguration"/></portlet:actionURL>
-<portlet:renderURL var="cancelUrl" portletMode="VIEW" />
+<portlet:actionURL var="cancelUrl" escapeXml="false"><portlet:param name="action" value="cancel"/></portlet:actionURL>
 <%--<portlet:resourceURL var="previewUrl" id="preview" escapeXml="false"/>--%>
 
 <c:if test="${includeJQuery}">
@@ -39,15 +39,11 @@
 
 <form:form id="${n}contentForm" commandName="form" action="${formUrl}" method="post">
     <form:textarea id="${n}content" path="content"/>
-
-    <p>
-    <form action="${cancelUrl}" method="post">
-      <button type="submit" name="cancel" value="cancel" class="btn-link">
-        <spring:message code="configurationForm.return"/>
-      </button>
-    </form>
-    </p>
-
+</form:form>
+<form:form action="${cancelUrl}" method="post">
+  <button type="submit" name="cancel" value="cancel" class="btn-link">
+    <spring:message code="configurationForm.return"/>
+  </button>
 </form:form>
 
 <script type="text/javascript">

--- a/src/main/webapp/WEB-INF/jsp/webcomponent/configureContent.jsp
+++ b/src/main/webapp/WEB-INF/jsp/webcomponent/configureContent.jsp
@@ -21,12 +21,13 @@
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 <c:set var="n"><portlet:namespace/></c:set>
 <portlet:actionURL var="formUrl" escapeXml="false"><portlet:param name="action" value="updateConfiguration"/></portlet:actionURL>
-<portlet:renderURL var="cancelUrl" portletMode="VIEW" />
+<portlet:actionURL var="cancelUrl" escapeXml="false"><portlet:param name="action" value="cancel"/></portlet:actionURL>
 
 <style type="text/css">
     #${n}contentForm { min-height: 100px; padding: 10px; margin: 10px; }
     #${n}contentForm div.btn-group {
         display: block;
+	margin: 5px 0 10px 0;
     }
     #${n}contentForm textarea {
          width: 100%;
@@ -40,14 +41,16 @@
 
 <form:form id="${n}contentForm" commandName="form" action="${formUrl}" method="post">
     <form:textarea id="${n}content" path="content" cols="100" rows="20" wrap="hard"/>
-    <div class="btn-group" style="margin: 5px 0 10px 0;">
+    <div class="btn-group">
       <button type="submit" name="update" value="update" class="btn-primary">
         <spring:message code="configurationForm.save"/>
       </button>
-      <form action="${cancelUrl}" method="post">
-      <button type="submit" name="cancel" value="cancel" class="btn-default">
+    </div>
+</form:form>
+<form:form action="${cancelUrl}" method="post">
+    <div class="btn-group">
+      <button type="submit" name="cancel" value="cancel" class="btn-link">
         <spring:message code="configurationForm.return"/>
       </button>
-      </form>
     </div>
 </form:form>


### PR DESCRIPTION
This PR fixes the "Return without saving" link on the Content Editor (config) page.  Previously, that link was actually causing the changes to get saved.

Tested through both portlet 'Configure' and through Portlet Admin flows.